### PR TITLE
Rename vertex variables for consistency

### DIFF
--- a/.github/workflows-broken/deploy.yml
+++ b/.github/workflows-broken/deploy.yml
@@ -36,4 +36,4 @@ jobs:
           git config --local user.name "$GITHUB_ACTOR"
           git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
           git commit -am "Deploy to GitHub Pages."
-          git push origin gh-pages # add the new deployment
+          git push https://$GH_PAT@github.com/$GITHUB_REPOSITORY gh-pages # add the new deployment

--- a/.github/workflows-broken/deploy.yml
+++ b/.github/workflows-broken/deploy.yml
@@ -26,16 +26,14 @@ jobs:
           git switch gh-pages
           ls -A | grep -v "^\.git$" | xargs rm -r # remove everything
           git restore --source=origin/master . # restore as if we were on master
-          git remote add upstream https://$GH_PAT@github.com:$GITHUB_REPOSITORY.git
       - name: Build
         run: mdbook build
       - name: Deploy
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
         run: |
-          git branch
           git add * || true # add all the changes
           git config --local user.name "$GITHUB_ACTOR"
           git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
           git commit -am "Deploy to GitHub Pages."
-          git push upstream HEAD:gh-pages # add the new deployment
+          git push origin gh-pages # add the new deployment

--- a/src/chapter_3_6.md
+++ b/src/chapter_3_6.md
@@ -9,18 +9,18 @@ We need normals, so let’s just state it in our vertex type and semantics!
 
 ```rust
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Semantics)]
-pub enum Semantics {
-  #[sem(name = "position", repr = "[f32; 3]", wrapper = "VPos")]
+pub enum VertexSemantics {
+  #[sem(name = "position", repr = "[f32; 3]", wrapper = "VertexPosition")]
   Position,
-  #[sem(name = "normal", repr = "[f32; 3]", wrapper = "VNor")]
+  #[sem(name = "normal", repr = "[f32; 3]", wrapper = "VertexNormal")]
   Normal,
 }
 
 #[derive(Clone, Copy, Debug, Vertex)]
-#[vertex(sem = "Semantics")]
+#[vertex(sem = "VertexSemantics")]
 struct Vertex {
-  position: VPos,
-  normal: VNor
+  position: VertexPosition,
+  normal: VertexNormal
 }
 ```
 
@@ -49,8 +49,8 @@ for shape in geometry.shapes {
       } else {
         let p = object.vertices[key.0];
         let n = object.normals[key.2.ok_or("missing normal for a vertex".to_owned())?];
-        let position = VPos::new([p.x as f32, p.y as f32, p.z as f32]);
-        let normal = VNor::new([n.x as f32, n.y as f32, n.z as f32]);
+        let position = VertexPosition::new([p.x as f32, p.y as f32, p.z as f32]);
+        let normal = VertexNormal::new([n.x as f32, n.y as f32, n.z as f32]);
         let vertex = Vertex { position, normal };
         let vertex_index = vertices.len() as VertexIndex;
 
@@ -203,18 +203,18 @@ struct ShaderInterface {
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Semantics)]
-pub enum Semantics {
-  #[sem(name = "position", repr = "[f32; 3]", wrapper = "VPos")]
+pub enum VertexSemantics {
+  #[sem(name = "position", repr = "[f32; 3]", wrapper = "VertexPosition")]
   Position,
-  #[sem(name = "normal", repr = "[f32; 3]", wrapper = "VNor")]
+  #[sem(name = "normal", repr = "[f32; 3]", wrapper = "VertexNormal")]
   Normal,
 }
 
 #[derive(Clone, Copy, Debug, Vertex)]
-#[vertex(sem = "Semantics")]
+#[vertex(sem = "VertexSemantics")]
 struct Vertex {
-  position: VPos,
-  normal: VNor
+  position: VertexPosition,
+  normal: VertexNormal
 }
 
 type VertexIndex = u32;
@@ -269,8 +269,8 @@ impl Obj {
           } else {
             let p = object.vertices[key.0];
             let n = object.normals[key.2.ok_or("missing normal for a vertex".to_owned())?];
-            let position = VPos::new([p.x as f32, p.y as f32, p.z as f32]);
-            let normal = VNor::new([n.x as f32, n.y as f32, n.z as f32]);
+            let position = VertexPosition::new([p.x as f32, p.y as f32, p.z as f32]);
+            let normal = VertexNormal::new([n.x as f32, n.y as f32, n.z as f32]);
             let vertex = Vertex { position, normal };
             let vertex_index = vertices.len() as VertexIndex;
 


### PR DESCRIPTION
Sorry I never got around to this @phaazon! Things have been hectic with finals.

This PR changes the name of `VPos` to `VertexPosition` as this is the name used in chapter 2. I also renamed `VNorm` to `VertexNormal` for consistency.