### PR TITLE
Rename vertex variables for consistency

### DIFF
--- a/src/chapter_3_6.md
+++ b/src/chapter_3_6.md
@@ -9,18 +9,18 @@ We need normals, so let’s just state it in our vertex type and semantics!
 
 ```rust
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Semantics)]
-pub enum Semantics {
-  #[sem(name = "position", repr = "[f32; 3]", wrapper = "VPos")]
+pub enum VertexSemantics {
+  #[sem(name = "position", repr = "[f32; 3]", wrapper = "VertexPosition")]
   Position,
-  #[sem(name = "normal", repr = "[f32; 3]", wrapper = "VNor")]
+  #[sem(name = "normal", repr = "[f32; 3]", wrapper = "VertexNormal")]
   Normal,
 }
 
 #[derive(Clone, Copy, Debug, Vertex)]
-#[vertex(sem = "Semantics")]
+#[vertex(sem = "VertexSemantics")]
 struct Vertex {
-  position: VPos,
-  normal: VNor
+  position: VertexPosition,
+  normal: VertexNormal
 }
 ```
 
@@ -49,8 +49,8 @@ for shape in geometry.shapes {
       } else {
         let p = object.vertices[key.0];
         let n = object.normals[key.2.ok_or("missing normal for a vertex".to_owned())?];
-        let position = VPos::new([p.x as f32, p.y as f32, p.z as f32]);
-        let normal = VNor::new([n.x as f32, n.y as f32, n.z as f32]);
+        let position = VertexPosition::new([p.x as f32, p.y as f32, p.z as f32]);
+        let normal = VertexNormal::new([n.x as f32, n.y as f32, n.z as f32]);
         let vertex = Vertex { position, normal };
         let vertex_index = vertices.len() as VertexIndex;
 
@@ -203,18 +203,18 @@ struct ShaderInterface {
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Semantics)]
-pub enum Semantics {
-  #[sem(name = "position", repr = "[f32; 3]", wrapper = "VPos")]
+pub enum VertexSemantics {
+  #[sem(name = "position", repr = "[f32; 3]", wrapper = "VertexPosition")]
   Position,
-  #[sem(name = "normal", repr = "[f32; 3]", wrapper = "VNor")]
+  #[sem(name = "normal", repr = "[f32; 3]", wrapper = "VertexNormal")]
   Normal,
 }
 
 #[derive(Clone, Copy, Debug, Vertex)]
-#[vertex(sem = "Semantics")]
+#[vertex(sem = "VertexSemantics")]
 struct Vertex {
-  position: VPos,
-  normal: VNor
+  position: VertexPosition,
+  normal: VertexNormal
 }
 
 type VertexIndex = u32;
@@ -269,8 +269,8 @@ impl Obj {
           } else {
             let p = object.vertices[key.0];
             let n = object.normals[key.2.ok_or("missing normal for a vertex".to_owned())?];
-            let position = VPos::new([p.x as f32, p.y as f32, p.z as f32]);
-            let normal = VNor::new([n.x as f32, n.y as f32, n.z as f32]);
+            let position = VertexPosition::new([p.x as f32, p.y as f32, p.z as f32]);
+            let normal = VertexNormal::new([n.x as f32, n.y as f32, n.z as f32]);
             let vertex = Vertex { position, normal };
             let vertex_index = vertices.len() as VertexIndex;
 
@@ -313,7 +313,7 @@ fn main_loop(mut surface: GlfwSurface) {
   let start_t = Instant::now();
   let back_buffer = surface.back_buffer().unwrap();
 
-  let program: Program<Semantics, (), ShaderInterface> = Program::from_strings(None, VS_STR, None, FS_STR)
+  let program: Program<VertexSemantics, (), ShaderInterface> = Program::from_strings(None, VS_STR, None, FS_STR)
     .unwrap()
     .ignore_warnings();
 


### PR DESCRIPTION
I couldn't figure out what went wrong with the rebase, so I decided to make a new PR.

This PR renames variables in chapter 3.6 to use the same names as those is chapter 2.

`VNor` is renamed to `VertexNormal`, `VPos` is renamed to `VertexPosition`, and the `Semantics` enum is renamed to `VertexSemantics`.