### PR TITLE
Updates chapter 1.3 for missing import

### DIFF
--- a/src/chapter_1_3.md
+++ b/src/chapter_1_3.md
@@ -19,10 +19,12 @@ It’s not _some_ kind: it **is** a [`Framebuffer`]. And guess what: you can acc
 
 So, let’s make our first cool render and make a color-varying background!  First, you will need to
 import one symbol from [luminance]: [`GraphicsContext`], which is a trait that allows you to run
-[luminance] code and talk to the GPU. We will be using pipelines for our rendering. A graphics
-pipeline is just a strongly typed description of what a GPU should do in order to render _things_
-into a [`Framebuffer`]. You can picture pipelines as [AST]s in which each node represents a given
-resource sharing and leaves are actual renders.
+[luminance] code and talk to the GPU. We will be using pipelines for our rendering, and therefore
+need access to the `PipelineState` `enum`.
+
+A graphics pipeline is just a strongly typed description of what a GPU should do in order to render
+_things_ into a [`Framebuffer`]. You can picture pipelines as [AST]s in which each node represents a
+given resource sharing and leaves are actual renders.
 
 > More on [pipelines here](https://docs.rs/luminance/latest/luminance/index.html#understanding-the-pipeline-architecture).
 

--- a/src/chapter_1_3.md
+++ b/src/chapter_1_3.md
@@ -20,7 +20,7 @@ It’s not _some_ kind: it **is** a [`Framebuffer`]. And guess what: you can acc
 So, let’s make our first cool render and make a color-varying background!  First, you will need to
 import one symbol from [luminance]: [`GraphicsContext`], which is a trait that allows you to run
 [luminance] code and talk to the GPU. We will be using pipelines for our rendering, and therefore
-need access to the `PipelineState` `enum`.
+need access to the `PipelineState` `struct`.
 
 A graphics pipeline is just a strongly typed description of what a GPU should do in order to render
 _things_ into a [`Framebuffer`]. You can picture pipelines as [AST]s in which each node represents a

--- a/src/chapter_1_3.md
+++ b/src/chapter_1_3.md
@@ -17,13 +17,21 @@ pixel storage for renders!
 It’s not _some_ kind: it **is** a [`Framebuffer`]. And guess what: you can access it via the
 [`Surface::back_buffer`] method.
 
-So, let’s make our first cool render and make a color-varying background! First, you will need to
+So, let’s make our first cool render and make a color-varying background!  First, you will need to
 import one symbol from [luminance]: [`GraphicsContext`], which is a trait that allows you to run
-[luminance] code and talk to the GPU. We will also use [`Instant`], from the standard library, to
+[luminance] code and talk to the GPU. We will be using pipelines for our rendering. A graphics
+pipeline is just a strongly typed description of what a GPU should do in order to render _things_
+into a [`Framebuffer`]. You can picture pipelines as [AST]s in which each node represents a given
+resource sharing and leaves are actual renders.
+
+> More on [pipelines here](https://docs.rs/luminance/latest/luminance/index.html#understanding-the-pipeline-architecture).
+
+We will also use [`Instant`], from the standard library, to
 handle low-precision yet sufficient time points.
 
 ```rust
 use luminance::context::GraphicsContext as _;
+use luminance::pipeline::PipelineState;
 use std::time::Instant;
 ```
 
@@ -65,13 +73,7 @@ once and for all and keep it around if you want to but in our case, since we’r
 a single pipeline, we’ll just chain everything.
 
 Then, the [`Builder::pipeline`] function, applied to the [`Builder`] object, creates a graphics
-pipeline. A graphics pipeline is just a strongly typed description of what a GPU should do in order
-to render _things_ into a [`Framebuffer`]. You can picture pipelines as [AST]s in which each node
-represents a given resource sharing and leaves are actual renders.
-
-> More on [pipelines here](https://docs.rs/luminance/latest/luminance/index.html#understanding-the-pipeline-architecture).
-
-In our case, we don’t want to render anything, we just want to modify the _back_ buffer background
+pipeline. In our case, we don’t want to render anything, we just want to modify the _back_ buffer background
 color. That is done with the arguments you pass to [`Builder::pipeline`]. The first one is the
 frame buffer to render to. In our case, it’s our _back_ buffer.
 


### PR DESCRIPTION
When going through this tutorial, i had to import `PipelineState` which was not mentioned. After adding this documented step, I thought it might be better to move the explanation of pipelines earlier up the page to explain this import.

I do not have enough understanding to check that the information is still valid and that the text still flows (as I am just following this tutorial for the first time). I'm happy if adjustments should be made.