### PR TITLE
Fix Frag Shader for WebGL

### DIFF
--- a/src/chapter_2_2.md
+++ b/src/chapter_2_2.md
@@ -122,11 +122,11 @@ In your project, add the `src/fs.glsl` file with the following content:
 in vec3 v_color;
 
 // we will output a single color
-out vec3 frag_color;
+out vec4 frag_color;
 
 void main() {
   // KISS
-  frag_color = v_color;
+  frag_color = vec4(v_color, 1.0);
 }
 ```
 


### PR DESCRIPTION
Hey there, I was following the tutorial with modifications to make it work for both Web and desktop from the same codebase, but I noticed that th web build was having a strange issue:

![Peek 2021-03-18 22-40](https://user-images.githubusercontent.com/25393315/111804028-ab4b1680-889d-11eb-90e1-bd1336284b93.gif)

It turns out it was because the fragment shader was missing the alpha channel and apparently that leaves the alpha value of the fragment up to the whim of the browser. It took me a while to troubleshoot, but hopefully this small change will keep others from suffering my fate. 😉