### PR TITLE
Apply minor fixes to first two chapters

### DIFF
--- a/examples/chapter-1/src/main.rs
+++ b/examples/chapter-1/src/main.rs
@@ -44,7 +44,7 @@ fn main_loop(surface: GlfwSurface) {
 
     // rendering code goes here
     // get the current time and create a color based on the time
-    let t = start_t.elapsed().as_millis() as f32 * 1e-3;
+    let t = start_t.elapsed().as_secs_f32();
     let color = [t.cos(), t.sin(), 0.5, 1.];
 
     let render = ctxt

--- a/examples/chapter-2/src/main.rs
+++ b/examples/chapter-2/src/main.rs
@@ -95,7 +95,7 @@ fn main_loop(surface: GlfwSurface) {
 
     // rendering code goes here
     // get the current time and create a color based on the time
-    let t = start_t.elapsed().as_millis() as f32 * 1e-3;
+    let t = start_t.elapsed().as_secs_f32();
     let color = [t.cos(), t.sin(), 0.5, 1.];
 
     let render = ctxt

--- a/src/chapter_1_1.md
+++ b/src/chapter_1_1.md
@@ -22,9 +22,9 @@ change the `[dependencies]` section according to the following:
 ```toml
 [dependencies]
 glfw = "0.41"
-luminance = "0.43"
-luminance-glfw = "0.15"
-luminance-windowing = "0.9"
+luminance = "0.44"
+luminance-glfw = "0.16"
+luminance-windowing = "0.10"
 ```
 
 Some explanations here:

--- a/src/chapter_1_3.md
+++ b/src/chapter_1_3.md
@@ -50,7 +50,7 @@ As you can see, getting the _back_ buffer is piece of cake. Now let’s handle t
 ```rust
     // rendering code goes here
     // get the current time and create a color based on the time
-    let t = start_t.elapsed().as_millis() as f32 * 1e-3;
+    let t = start_t.elapsed().as_secs_f32();
     let color = [t.cos(), t.sin(), 0.5, 1.];
 
     let render = ctxt

--- a/src/chapter_1_3.md
+++ b/src/chapter_1_3.md
@@ -154,7 +154,7 @@ fn main_loop(surface: GlfwSurface) {
 
     // rendering code goes here
     // get the current time and create a color based on the time
-    let t = start_t.elapsed().as_millis() as f32 * 1e-3;
+    let t = start_t.elapsed().as_secs_f32();
     let color = [t.cos(), t.sin(), 0.5, 1.];
 
     let render = ctxt

--- a/src/chapter_1_3.md
+++ b/src/chapter_1_3.md
@@ -20,10 +20,12 @@ It’s not _some_ kind: it **is** a [`Framebuffer`]. And guess what: you can acc
 So, let’s make our first cool render and make a color-varying background! First, you will need to
 import one symbol from [luminance]: [`GraphicsContext`], which is a trait that allows you to run
 [luminance] code and talk to the GPU. We will also use [`Instant`], from the standard library, to
-handle low-precision yet sufficient time points.
+handle low-precision yet sufficient time points. Add [`PipelineState`] to support graphics
+pipelines: more on that later in this chapter.
 
 ```rust
 use luminance::context::GraphicsContext as _;
+use luminance::pipeline::PipelineState;
 use std::time::Instant;
 ```
 

--- a/src/chapter_2_1.md
+++ b/src/chapter_2_1.md
@@ -30,7 +30,7 @@ to worry about those, because a crate exists to automatically implement such a t
 First thing first: add [luminance-derive] to your project’s `[dependencies]` section:
 
 ```toml
-luminance-derive = "0.6"
+luminance-derive = "0.7"
 ```
 
 Simple. One last thing: when you will use the `Vertex` derive annotation, you will have to provide

--- a/src/chapter_2_3.md
+++ b/src/chapter_2_3.md
@@ -157,7 +157,7 @@ fn main_loop(surface: GlfwSurface) {
 
     // rendering code goes here
     // get the current time and create a color based on the time
-    let t = start_t.elapsed().as_millis() as f32 * 1e-3;
+    let t = start_t.elapsed().as_secs_f32();
     let color = [t.cos(), t.sin(), 0.5, 1.];
 
     let render = ctxt


### PR DESCRIPTION
I propose update of luminance dependencies mentioned in the book.
Besides that I suggest a bit of code clarification.
- Usage of `as_secs_f32` instead of `as_millis`;
- Mention of `PipelineState` in the beginning of chapter 1.3.